### PR TITLE
single character path components

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ module.exports = function (input, length) {
 		throw new TypeError('Expected length to be a number');
 	}
 
+	if (input.length <= length) {
+		return input;
+	}
+
 	var TRUNCATE_SYMBOL_LENGTH = 2;
 	var parsed = url.parse(input);
 	var remainingLength = length - (input.length - parsed.path.length) - TRUNCATE_SYMBOL_LENGTH;
@@ -26,7 +30,7 @@ module.exports = function (input, length) {
 		}
 
 		pathPartsRet.push(x);
-		remainingLength -= x.length;
+		remainingLength -= x.length + 1;
 	}
 
 	parsed.pathname = pathPartsRet.reverse().join('/');

--- a/test.js
+++ b/test.js
@@ -5,5 +5,7 @@ var fn = require('./');
 test(function (t) {
 	t.is(fn('http://sindresorhus.com/foo/bar/baz/faz', 30), 'http://sindresorhus.com/…/faz');
 	t.is(fn('http://example.com/a/cool/page/that-is-really-deeply/nested/', 40), 'http://example.com/…/nested/');
+	t.is(fn('http://example.com/a/b/c/d', 24).length, 24);
+	t.is(fn('http://example.com/a/b/c', 24), 'http://example.com/a/b/c');
 	t.end();
 });


### PR DESCRIPTION
Currently `truncateUrl('http://example.com/a/b/c/d', 24)` returns `'http://example.com/a/b/c/d'` (with length&nbsp;26) instead of `'http://example.com/…/c/d'`.
